### PR TITLE
nevez: allow '-' in tags inside the changelog file

### DIFF
--- a/src/nevez.rs
+++ b/src/nevez.rs
@@ -345,7 +345,7 @@ fn update_changelog<P: AsRef<Path>>(
     in_place: bool,
 ) -> Result<()> {
     let mut inserted = false;
-    let pat = Regex::new(r"^##\s+\[[\w.]+\]\s+-\s+[\d]{4}-[\d]{2}-[\d]{2}$")?;
+    let pat = Regex::new(r"^##\s+\[[\w\-.]+\]\s+-\s+[\d]{4}-[\d]{2}-[\d]{2}$")?;
     let input = File::open(&changelog)?;
     let reader = BufReader::new(input);
     let mut tmp = OsString::from(&changelog.as_ref());


### PR DESCRIPTION
Some tags have a semantic that includes a '-', e.g: x.y.z-rcX.
The current regexp will not include them, causing the new changelog to be
at the end of the file.